### PR TITLE
Add yju.txt

### DIFF
--- a/lib/domains/kr/ac/yju.txt
+++ b/lib/domains/kr/ac/yju.txt
@@ -1,0 +1,1 @@
+Yeungjin College


### PR DESCRIPTION
Add yju.txt for @g.yju.ac.kr 

Domain: https://computer.yju.ac.kr/
Curriculum: https://computer.yju.ac.kr/page_jzsC49
Our university's classes consist of three years of IT education curriculum.

https://www.youtube.com/channel/UCIBpw77RP6q0NjkxpU_W13w/videos
This is the link to the official YouTube channel that posts the capstone design work.

https://itcenter.yju.ac.kr/xe_board_notice/6834
This is a page announcing that we use g.yju.ac.kr as university email address.